### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module fingertip
 go 1.16
 
 require (
-	github.com/buffrr/letsdane v0.6.0
+	github.com/buffrr/letsdane v0.6.1
 	github.com/emersion/go-autostart v0.0.0-20210130080809-00ed301c8e9a
 	github.com/ethereum/go-ethereum v1.10.8
 	github.com/getlantern/systray v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buffrr/hsig0 v0.0.0-20200928223456-eca10c3b5481/go.mod h1:2Afpm44R6zbhXwVIXQt+e+pHH6Jm66hxqOmdzrHzjZQ=
-github.com/buffrr/letsdane v0.6.0 h1:1ZDbkBAb8xWfCPV4kK2Gf5Bd7d6ANfrR+ORdWenEt5E=
-github.com/buffrr/letsdane v0.6.0/go.mod h1:8U9aUvwZSoQ0qm/7X8HIq2zv75dLagsE0ZBcz0ArBBE=
+github.com/buffrr/letsdane v0.6.1 h1:aV8YYB6/RnEIzuckyK/gmgIZKWSwgJj5LiRCMpz8bs0=
+github.com/buffrr/letsdane v0.6.1/go.mod h1:8U9aUvwZSoQ0qm/7X8HIq2zv75dLagsE0ZBcz0ArBBE=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=

--- a/main.go
+++ b/main.go
@@ -400,6 +400,6 @@ func getProcPath() (string, error) {
 func init() {
 	// letsdane shows the version name
 	// in the footer on errors
-	// 0.6 is the version used in go.mod
-	letsdane.Version = fmt.Sprintf("0.6 - fingertip (v%s)", Version)
+	// 0.6.1 is the version used in go.mod
+	letsdane.Version = fmt.Sprintf("0.6.1 - fingertip (v%s)", Version)
 }


### PR DESCRIPTION
This PR updates linux build to use Go 1.17 to take advantage of some improvements to the language and updates letsdane to v0.6.1. Creating this as a PR to make sure GH action workflow doesn't break.