### PR TITLE
Patch in glib in AppImage

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,6 +57,12 @@ jobs:
           go build -trimpath -o ./builds/linux/appdir/usr/bin
           ls -l builds/linux/appdir/usr/bin/
 
+      - name: Store fingertip binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: fingertip-bin
+          path: ./builds/linux/appdir/usr/bin/fingertip
+
       - name: Download hnsd binary
         uses: actions/download-artifact@v2
         with:
@@ -68,11 +74,25 @@ jobs:
         run: |
           ls -l appdir/usr/bin/
           chmod +x appdir/usr/bin/hnsd
-          wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-          chmod a+x linuxdeployqt-continuous-x86_64.AppImage
-          ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/fingertip.desktop -appimage -executable=appdir/usr/bin/hnsd
+          wget -c -nv "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+          chmod +x linuxdeploy-x86_64.AppImage
+          ./linuxdeploy-x86_64.AppImage --appdir appdir --output appimage
 
-      - name: Store fingertip binary
+      # https://bbs.archlinux.org/viewtopic.php?pid=1994258#p1994258
+      # Most systems don't have the latest glib and we require (2.69.1+),
+      # so we extract the AppImage, copy glib into it, then replace the AppImage
+      - name: Patch AppImage to include glib
+        working-directory: ./builds/linux
+        run: |
+          wget -c -nv "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x appimagetool-x86_64.AppImage
+          OUTPUT=$(ls Fingertip-*.AppImage)
+          ./$OUTPUT --appimage-extract
+          wget -c -nv "https://archive.archlinux.org/packages/g/glib2/glib2-2.70.2-1-x86_64.pkg.tar.zst"
+          tar xvf glib2-2.70.2-1-x86_64.pkg.tar.zst -C squashfs-root --use-compress-program=unzstd
+          ./appimagetool-x86_64.AppImage squashfs-root $OUTPUT
+
+      - name: Store fingertip AppImage
         uses: actions/upload-artifact@v2
         with:
           name: fingertip-appimage

--- a/builds/linux/README.md
+++ b/builds/linux/README.md
@@ -2,19 +2,16 @@
 
 Make sure both `hnsd` and `fingertip` binaries are in `./appdir/usr/bin/`.
 
-Download / install [`linuxdeployqt`](https://github.com/probonopd/linuxdeployqt). Then build AppImage.
+Download / install [`linuxdeploy`](https://github.com/linuxdeploy/linuxdeploy).
+Then build AppImage.
 
 ```sh
-# download linuxdeployqt
-wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-chmod +x linuxdeployqt-continuous-x86_64.AppImage
+# download linuxdeploy
+wget -c -nv "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+chmod +x linuxdeploy-x86_64.AppImage
 
 # build
-./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/fingertip.desktop -appimage -always-overwrite
+./linuxdeploy-x86_64.AppImage --appdir appdir --output appimage
 ```
 
 AppImage will be in current directory.
-
-> **Note:** Builds depend on the glibc in your system. This build will only work on systems with glibc >= current version. This is why the CI builds in an old Ubuntu 18.04 container. [More info](https://github.com/probonopd/linuxdeployqt#a-note-on-binary-compatibility)
-
-> `linuxdeployqt` may throw an error if glibc is too new (yes, new). Add `-unsupported-allow-new-glibc` to bypass it.


### PR DESCRIPTION
Closes #9, Closes #12.

Around 4 months ago, [this PR was merged into glib2](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2169) and then released in version `2.69.1`.

This PR:
- Replaces [probonopd/linuxdeployqt](https://github.com/probonopd/linuxdeployqt) with [linuxdeploy/linuxdeploy](https://github.com/linuxdeploy/linuxdeploy) which is more modular and better at detection (we pass in less arguments).
- Patches in glib into the AppImage (extract fs, copy files, build again) based on https://bbs.archlinux.org/viewtopic.php?pid=1994258#p1994258
- Exports fingertip binary also (not just the AppImage)
- Updates packaging readme

I've tested this on Manjaro / Arch. Would be great if someone can test it on Ubuntu before merging.