### PR TITLE
Add polygon HIP-5 resolver

### DIFF
--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -14,6 +14,7 @@ const (
 	DefaultRootAddr         = "127.0.0.1:9591"
 	DefaultRecursiveAddr    = "127.0.0.1:9592"
 	DefaultEthereumEndpoint = "https://mainnet.infura.io/v3/b0933ce6026a4e1e80e89e96a5d095bc"
+	DefaultPolygonEndpoint = "https://polygon-mainnet.infura.io/v3/b0933ce6026a4e1e80e89e96a5d095bc"
 )
 
 // User Represents user facing configuration
@@ -22,6 +23,7 @@ type User struct {
 	RootAddr         string `mapstructure:"ROOT_ADDRESS"`
 	RecursiveAddr    string `mapstructure:"RECURSIVE_ADDRESS"`
 	EthereumEndpoint string `mapstructure:"ETHEREUM_ENDPOINT"`
+	PolygonEndpoint  string `mapstructure:"POLYGON_ENDPOINT"`
 }
 
 // Stored config
@@ -92,6 +94,7 @@ func ReadUserConfig(path string) (config User, err error) {
 	viper.SetDefault("ROOT_ADDRESS", DefaultRootAddr)
 	viper.SetDefault("RECURSIVE_ADDRESS", DefaultRecursiveAddr)
 	viper.SetDefault("ETHEREUM_ENDPOINT", DefaultEthereumEndpoint)
+	viper.SetDefault("POLYGON_ENDPOINT", DefaultPolygonEndpoint)
 
 	err = viper.ReadInConfig()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -342,9 +342,14 @@ func (a *App) NewResolver() (resolver.Resolver, error) {
 	if err != nil {
 		return nil, err
 	}
+	polygonExt, err := resolvers.NewEthereum(a.usrConfig.PolygonEndpoint)
+	if err != nil {
+		return nil, err
+	}
 
 	// Register HIP-5 handlers
 	hip5.RegisterHandler("_eth", ethExt.Handler)
+	hip5.RegisterHandler("_matic", polygonExt.Handler)
 	hip5.SetQueryMiddleware(a.config.Debug.GetDNSProbeMiddleware())
 	a.config.Debug.SetCheckSynced(a.proc.Synced)
 


### PR DESCRIPTION
XNHNS is on Polygon: https://xnhns.on.fleek.co/ and uses the `._matic` namespace. This PR adds a HIP-5 resolver for it.

Since ENSRegistry is unmodified, @buffrr's modular code made it very easy to add it :)

**TODO for Impervious:**
I used the same Infura project id that's already used for ethereum mainnet, but Polygon needs to be enabled in the account first.

Working site to test: http://sh8/
