### PR TITLE
Support for resolving TLDs with punycodes

### DIFF
--- a/internal/resolvers/ethereum.go
+++ b/internal/resolvers/ethereum.go
@@ -72,7 +72,12 @@ func (e *Ethereum) GetResolverAddress(node, registryAddress string) (common.Addr
 		return common.Address{}, err
 	}
 
-	addr, err := registry.Resolver(nil, EnsNode(node))
+	normalizedName, err := Normalize(node)
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	addr, err := registry.Resolver(nil, EnsNode(normalizedName))
 	if err != nil {
 		return common.Address{}, err
 	}


### PR DESCRIPTION
The current implementation is not able to resolve root domains with puny codes. 

ENS supports unicode characters and therefore TLDs with special characters can be directly registered as they are without mapping to punycodes or other encodings. 

As an example, if we take `☢㣎`, punycode `xn--j4h059d`, we can create an ENS registry with `☢㣎` whose hash is `0x9944186df8dbb5bd89fd1d89d38b3889b75f7aa9fd3a0b66921a49372935804c`.

When typing `subdomain.☢㣎` in a browser, it will be mapped to `subdomain.xn--j4h059d` which will trigger fingertip to query the handshake record for `xn--j4h059d` resulting in a contract address which then needs to be queries using `☢㣎` rather than its punycode equivalent. 

In short the flow currently is:
1. type `subdomain.☢㣎` in brower 
2. browser maps to `domain.xn--j4h059d`
3. Fingertip queries handshake for `.xn--j4h059d` and gets ENS registry contract address
4. Fingertip queries contract for `domain.xn--j4h059d`

But step 4 should be:
4. Fingertip queries contract for `domain.☢㣎`

This PR normalises the name to resolve before we call the ENS contract.