### PR TITLE
Use checkpoints + hnsd dns api

### DIFF
--- a/internal/config/debug.go
+++ b/internal/config/debug.go
@@ -31,6 +31,7 @@ type Debugger struct {
 	checkSynced        func() bool
 
 	blockHeight uint64
+	progress    float64
 
 	lastPing time.Time
 	sync.RWMutex
@@ -38,6 +39,7 @@ type Debugger struct {
 
 type DebugInfo struct {
 	BlockHeight   uint64 `json:"blockHeight"`
+	Progress      float64 `json:"progress"`
 	ProbeURL      string `json:"proxyProbeUrl"`
 	ProbeReached  bool   `json:"proxyProbeReached"`
 	Syncing       bool   `json:"syncing"`
@@ -122,11 +124,12 @@ func exchangeWithRetry(m *dns.Msg, addrs []string) (r *dns.Msg, rtt time.Duratio
 	return
 }
 
-func (d *Debugger) SetBlockHeight(h uint64) {
+func (d *Debugger) SetChainInfo(height uint64, progress float64) {
 	d.Lock()
 	defer d.Unlock()
 
-	d.blockHeight = h
+	d.blockHeight = height
+	d.progress = progress
 }
 
 func (d *Debugger) Ping() {
@@ -183,6 +186,7 @@ func (d *Debugger) GetInfo() DebugInfo {
 	}
 	return DebugInfo{
 		BlockHeight:        d.blockHeight,
+		Progress:           d.progress,
 		ProbeURL:           "http://" + d.proxyProbeDomain,
 		ProbeReached:       d.proxyProbeReached,
 		Syncing:            d.checkSynced != nil && !d.checkSynced(),

--- a/internal/config/pages/index.html
+++ b/internal/config/pages/index.html
@@ -116,7 +116,7 @@
         }
 
         td:nth-child(2) {
-            width: 90px;
+            width: 140px;
         }
 
     </style>
@@ -214,7 +214,8 @@
             probeChecks = 0;
         }
 
-        handshakeStatus.innerHTML = data.syncing ? "<span class='warning'>Syncing ...</span>" :
+        const progress = Math.round(data.progress * 100 * 100) / 100;
+        handshakeStatus.innerHTML = data.syncing ? `<span class='warning'>Syncing (${progress}%)</span>` :
             "<span class='success'>Ready</span>";
 
         blockHeight.innerText = data.blockHeight;

--- a/internal/resolvers/proc/hns.go
+++ b/internal/resolvers/proc/hns.go
@@ -232,7 +232,7 @@ func (h *HNSProc) Synced() bool {
 	h.RLock()
 	defer h.RUnlock()
 
-	return h.progress == 1
+	return h.progress >= 0.999
 }
 
 func (h *HNSProc) Start(stopErr chan<- error) {

--- a/internal/resolvers/proc/hns.go
+++ b/internal/resolvers/proc/hns.go
@@ -31,7 +31,7 @@ type HNSProc struct {
 }
 
 func NewHNSProc(procPath string, rootAddr, recursiveAddr string, configPath string) (*HNSProc, error) {
-	args := []string{"--ns-host", rootAddr, "--rs-host", recursiveAddr, "--pool-size", "4", "-x", configPath}
+	args := []string{"--ns-host", rootAddr, "--rs-host", recursiveAddr, "--pool-size", "4", "-t", "-x", configPath}
 
 	if !strings.HasSuffix(procPath, processExtension) {
 		procPath += processExtension

--- a/internal/resolvers/proc/hns.go
+++ b/internal/resolvers/proc/hns.go
@@ -28,8 +28,8 @@ type HNSProc struct {
 	sync.RWMutex
 }
 
-func NewHNSProc(procPath string, rootAddr, recursiveAddr string) (*HNSProc, error) {
-	args := []string{"--ns-host", rootAddr, "--rs-host", recursiveAddr, "--pool-size", "4"}
+func NewHNSProc(procPath string, rootAddr, recursiveAddr string, configPath string) (*HNSProc, error) {
+	args := []string{"--ns-host", rootAddr, "--rs-host", recursiveAddr, "--pool-size", "4", "-x", configPath}
 
 	if !strings.HasSuffix(procPath, processExtension) {
 		procPath += processExtension

--- a/internal/resolvers/proc/hns.go
+++ b/internal/resolvers/proc/hns.go
@@ -114,7 +114,7 @@ func (h *HNSProc) goRefreshStatus() {
 		for range ticker.C {
 			if !h.procStarted {
 				ticker.Stop()
-				continue
+				break
 			}
 
 			// Create DNS Query

--- a/main.go
+++ b/main.go
@@ -251,13 +251,13 @@ func main() {
 			case <-ticker.C:
 				if !app.proc.Started() {
 					ui.Data.SetBlockHeight("--")
-					app.config.Debug.SetBlockHeight(0)
+					app.config.Debug.SetChainInfo(0, 0)
 					continue
 				}
 
-				height := app.proc.GetHeight()
-				ui.Data.SetBlockHeight(fmt.Sprintf("#%d", height))
-				app.config.Debug.SetBlockHeight(height)
+				height, progress := app.proc.GetChainInfo()
+				ui.Data.SetBlockHeight(fmt.Sprintf("#%d (%.2f%%)", height, progress*100))
+				app.config.Debug.SetChainInfo(height, progress)
 			}
 
 		}

--- a/main.go
+++ b/main.go
@@ -317,7 +317,7 @@ func NewApp(appConfig *config.App) (*App, error) {
 	app.proxyURL = config.GetProxyURL(usrConfig.ProxyAddr)
 	app.usrConfig = &usrConfig
 
-	if hnsProc, err = proc.NewHNSProc(appConfig.DNSProcPath, usrConfig.RootAddr, usrConfig.RecursiveAddr); err != nil {
+	if hnsProc, err = proc.NewHNSProc(appConfig.DNSProcPath, usrConfig.RootAddr, usrConfig.RecursiveAddr, appConfig.Path); err != nil {
 		return nil, err
 	}
 	hnsProc.SetUserAgent("fingertip:" + Version)


### PR DESCRIPTION
### hnsd: use checkpoints
Uses the `-x <prefix-dir>` option of hnsd to store checkpoints on disk. See https://github.com/handshake-org/hnsd/pull/99 for more info.
The file is stored in Fingertip's config directory (along with dnssec cert, etc.)

### hnsd: use dns api to get sync status
Instead of assuming that hnsd synced after 20 seconds, now the height and progress is fetched from hnsd every second. The tray menu and web page is updated to show the sync % like:
![image](https://user-images.githubusercontent.com/5113343/219969495-636ffb47-9ad4-4d25-ad6c-ca1e2d802be7.png)
See https://github.com/handshake-org/hnsd/pull/102 for more info.

I'm new to Go so may have missed best practices / easier ways to do things, so feel free to leave any number of comments to change or add your own commits :)