### PR TITLE
ci: update actions and export fingertip binary

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout hnsd repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'handshake-org/hnsd'
 
@@ -21,7 +21,7 @@ jobs:
           ls -l
 
       - name: Store hnsd binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: hnsd-bin
           path: ./hnsd
@@ -31,26 +31,17 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Install go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: '1.17'
-
-      - name: Checkout repository
-        uses: actions/checkout@v2
+          cache: true # Cache go modules
 
       - name: Install dependencies
         run: sudo apt install -y libgtk-3-dev libappindicator3-dev libunbound-dev
-
-      - name: Cache go modules
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Build fingertip
         run: |
@@ -58,7 +49,7 @@ jobs:
           ls -l builds/linux/appdir/usr/bin/
 
       - name: Download hnsd binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: hnsd-bin
           path: builds/linux/appdir/usr/bin
@@ -73,7 +64,13 @@ jobs:
           ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/fingertip.desktop -appimage -executable=appdir/usr/bin/hnsd
 
       - name: Store fingertip binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
+        with:
+          name: fingertip-bin
+          path: ./builds/linux/appdir/usr/bin/fingertip
+
+      - name: Store fingertip appimage
+        uses: actions/upload-artifact@v3
         with:
           name: fingertip-appimage
           path: ./builds/linux/Fingertip*.AppImage


### PR DESCRIPTION
Current GitHub Actions runs show a bunch of deprecation warnings:
![image](https://user-images.githubusercontent.com/5113343/219972316-21c24c3e-c893-4538-8838-547ca3a0306b.png)

All are updated, except ubuntu 18.04, which shouldn't be done till April 2023 (EOL)